### PR TITLE
BUGFIX: Only compress when rendering `live`

### DIFF
--- a/Resources/Private/TypoScript/Root.ts2
+++ b/Resources/Private/TypoScript/Root.ts2
@@ -2,9 +2,11 @@ prototype(TYPO3.Neos:Page) {
     head.@process.compression {
         expression = ${Flownative.Compressor.compress(value)}
         @position = 'end 999999999'
+        @if.isLive = ${node.context.live}
     }
     body.@process.compression {
         expression = ${Flownative.Compressor.compress(value)}
         @position = 'end 999999999'
+        @if.isLive = ${node.context.live}
     }
 }


### PR DESCRIPTION
This is done to prevent newlines in inspector editors (`TextAreaEditor`) from getting removed.

Closes #2
